### PR TITLE
修复了三角化时，indices数组赋值错误的bug

### DIFF
--- a/NavMeshGenVisual/Assets/Script/NMGen/PolyMeshFieldBuilder.cs
+++ b/NavMeshGenVisual/Assets/Script/NMGen/PolyMeshFieldBuilder.cs
@@ -588,7 +588,7 @@ namespace NMGen
                 }
                 else
                 {
-                    inoutIndices[j] = inoutIndices[j] | DEFLAG; 
+                    inoutIndices[j] = inoutIndices[j] & DEFLAG; 
                 }
 
                 if( isValidPartition(j,getNextIndex(jPlus1,inoutIndices.Count),verts,inoutIndices)) 
@@ -597,7 +597,7 @@ namespace NMGen
                 }
                 else
                 {
-                    inoutIndices[jPlus1] = inoutIndices[jPlus1] | DEFLAG; 
+                    inoutIndices[jPlus1] = inoutIndices[jPlus1] & DEFLAG; 
                 }
 
             } // while innoutIndices


### PR DESCRIPTION
如果j点是一个耳朵（可以被切割），则应该 | FLAG，但是如果不是的话，应该 & DEFLAG，而不是 | DEFLAG。