### PR TITLE
计算Bounds时，点的Z坐标的Index错误

### DIFF
--- a/NavMeshGenVisual/Assets/Script/NMGen/DetailMeshBuilder.cs
+++ b/NavMeshGenVisual/Assets/Script/NMGen/DetailMeshBuilder.cs
@@ -130,8 +130,8 @@ namespace NMGen
                     int pVert = sourcePolys[pPoly + vertOffset] * 3;
                     polyXZBounds[pxmin] = Math.Min(polyXZBounds[pxmin], sourceVerts[pVert]);
                     polyXZBounds[pxmax] = Math.Max(polyXZBounds[pxmax], sourceVerts[pVert]);
-                    polyXZBounds[pzmin] = Math.Min(polyXZBounds[pzmin], sourceVerts[pVert]);
-                    polyXZBounds[pzmax] = Math.Max(polyXZBounds[pzmax], sourceVerts[pVert]);
+                    polyXZBounds[pzmin] = Math.Min(polyXZBounds[pzmin], sourceVerts[pVert + 2]);
+                    polyXZBounds[pzmax] = Math.Max(polyXZBounds[pzmax], sourceVerts[pVert + 2]);
 
                     totalPolyVertCount++; 
                 } // for maxVertsPerPoly 


### PR DESCRIPTION
pVert是基地址，pVert + 1是 y，pVert + 2为z