### PR TITLE
判断两个点x坐标是否相等，方法错误

### DIFF
--- a/NavMeshGenVisual/Assets/Script/NMGen/DetailMeshBuilder.cs
+++ b/NavMeshGenVisual/Assets/Script/NMGen/DetailMeshBuilder.cs
@@ -314,7 +314,7 @@ namespace NMGen
                     //字典序,先对比 x的，再对比z ，反正就是坐标较小那个为先
                     //TODO 不明白为啥要搞这个？保护顶点的处理顺序一致？
                     //两个点的x坐标非常相近？
-                    if( Math.Abs(sourcePoly[pSourceVertA] - sourcePoly[pSourceVertB]) < float.MinValue )  
+                    if( Math.Abs(sourcePoly[pSourceVertA] - sourcePoly[pSourceVertB]) < 1e-6 )  
                     {
                         //A的Z坐标稍微大点？
                         if( sourcePoly[pSourceVertA+2] > sourcePoly[pSourceVertB+2] )


### PR DESCRIPTION
使用Math.Abs对x的差值取绝对值，比较绝对值，如果小于0.000001，也即是1e-6，则认为x相等，而不是float.MinValue，float.MinValue 是-3.4028235E+38， 是一个复数，abs所得的值也不可能是个复数，显然是这里写错了